### PR TITLE
change seg look up to array, not switch

### DIFF
--- a/bcdTo7segCommonCath.c
+++ b/bcdTo7segCommonCath.c
@@ -5,60 +5,46 @@
  * Created on May 30, 2016, 7:41 PM
  */
 
-
-
 #include <xc.h>
+#include <pic18f4420.h>
+#include "main.h"
 
-char bcdTo7seg(char value) {
-    switch (value)
+char combos [2] [16] = {{0x3F, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F, 0x77, 0x7C, 0x39, 0x5E, 0x79, 0x71}, // seg a aligned on lhs common cathode combos
+                        {0xF3, 0x60, 0xB5, 0xF4, 0x66, 0xD6, 0xD7, 0x70, 0xF7, 0xF6, 0x77, 0xC7, 0x93, 0xE5, 0x97, 0x17}};// seg a aligned on rhs, common cathode combos
+
+char manipulate = 0x00;                                                         // char used to perform desired manipulation before returning
+
+
+
+char bcdTo7seg(char value, char comTerm, char side)                            // accepts BCD value (the thing you want to look up), C or A for common terminal, L or R for alignment of segment A
+{
+    if((value >= 0)&&(value <=15))                                              // perform some checking to make sure we don't dive off the end of the array
     {
-        case(0):
-            return 0b00111111;                                                  // segment a is the LSB
-            break;
-        case (1):
-            return 0b00000110;
-            break;
-        case (2):
-            return 0b01011011;
-            break;
-        case (3):
-            return 0b01001111;
-        case (4):
-            return 0b01100110;
-            break;
-        case(5):
-            return 0b01101101;
-            break;
-        case(6):
-            return 0b01111101;
-            break;
-        case(7):
-            return 0b00000111;
-            break;
-        case(8):
-            return 0b01111111;
-            break;
-        case(9):
-            return 0b01101111;
-            break;
-        case(10):
-            return 0b01110111;                                                  //A
-            break;
-        case(11):
-            return 0b01111100;                                                  //b
-            break;
-        case (12):
-            return 0b00111001;                                                  //C
-            break;
-        case (13):
-            return 0b01011110;                                                  //d
-            break;
-        case (14):
-            return 0b01111001;                                                  //E
-            break;
-        case (15):
-            return 0b01110001;                                                  //F
-            break;
+        if (side == 'L')
+        {
+            manipulate = combos[0] [value];                                     // read the bit combination out of the array
+            manipulate = bitInvert(manipulate, comTerm);                        // invert it if need be for common anode
+            return manipulate;                                                  // return the result
+        }
+        else if(side == 'R')                                                    // repeat the process for results with segment a aligned on the right hand side
+        {
+            manipulate = combos[1] [value];
+            manipulate = bitInvert(manipulate, comTerm);
+            return manipulate;
+        }
+        else
+            return 0;                                                           // if any of the inputs were unexpected return 0
     }
-    return;
+    else
+        return 0;
+}
+
+char bitInvert (char invertIt, char comTerm)
+{
+    if(comTerm == 'A')                                                          // if the common terminal is anode the bits need to be inverted
+        return invertIt ^ 0xFF;
+    else if (comTerm =='C')
+        return invertIt;                                                        // if not just return the bit combination as it is
+    else
+        return 0;                                                               // trap for unexpected common terminal request
 }

--- a/driveDisplay.c
+++ b/driveDisplay.c
@@ -17,31 +17,31 @@ void driveDisp (void)
     {
         case 0:
             LATD |= selectWkts;
-            numberBits.Byte = bcdTo7seg(7);
+            numberBits.Byte = bcdTo7seg(7,'C','L');
             break;
         case 1:
             LATD |= selectOverU;
-            numberBits.Byte = bcdTo7seg(6);
+            numberBits.Byte = bcdTo7seg(6,'C','L');
             break;
         case 2:
             LATD |= selectOverT;
-            numberBits.Byte = bcdTo7seg(5);
+            numberBits.Byte = bcdTo7seg(5,'C','L');
             break;
         case 3:
             LATD |= selectScoreThs;
-            numberBits.Byte = bcdTo7seg(1);
+            numberBits.Byte = bcdTo7seg(1,'C','L');
             break;
         case 4:
             LATD |= selectScoreHun;
-            numberBits.Byte = bcdTo7seg(2);
+            numberBits.Byte = bcdTo7seg(2,'C','L');
             break;
         case 5:
             LATD |= selectScoreTen;
-            numberBits.Byte = bcdTo7seg(3);
+            numberBits.Byte = bcdTo7seg(3,'C','L');
             break;
         case 6:
             LATD |= selectScoreUni;
-            numberBits.Byte = bcdTo7seg(4);
+            numberBits.Byte = bcdTo7seg(4,'C','L');
             break;
         default:
             selCtr = 0;

--- a/main.h
+++ b/main.h
@@ -6,7 +6,8 @@ void high_int (void);
 void low_int (void);
 void timer0isr (void);
 void driveDisp (void);
-char bcdTo7seg(char value);
+char bcdTo7seg(char value, char comTerm, char side);
+char bitInvert (char invertIt, char side);
 
 
 


### PR DESCRIPTION
As stated 7 seg combinations are now retrieved from an array.

Combinations are common anode as I forgot I have a ULN2003 in the circuit that inverts them to make them common cathode.  Inversion works as intended as far as I am able to test.
